### PR TITLE
Support autodetect on old DVI monitors

### DIFF
--- a/camplayer/utils/utils.py
+++ b/camplayer/utils/utils.py
@@ -157,6 +157,13 @@ def get_display_mode(display=2):
             res_width   = int(tmp.group(3))
             res_height  = int(tmp.group(4))
             framerate   = int(tmp.group(5))
+        else:
+            tmp = re.search('^state.+(CUSTOM).*[\s*\S*]* (\d+)x(\d+).+@ (\d+)', response)
+            if tmp:
+                hdmi_group  = tmp.group(1)
+                res_width   = int(tmp.group(2))
+                res_height  = int(tmp.group(3))
+                framerate   = int(tmp.group(4))
 
         response = subprocess.check_output(
             ['tvservice', '--device', str(display), '--name'],


### PR DESCRIPTION
I have 10 old DVI monitors that result in tvservice yielding "state 0x6 [DVI CUSTOM RGB full unknown AR], 1440x900 @ 60.00Hz, progressive" which is not properly processed by utils.py. Since tvservice does this for every resolution the monitors support, rather then keep changing the config, I traced the source.

Sidenote: tvservice does normally read and list the monitors mode. Only when asking the active status does it list custom. So the root problem is probably somewhere in tvservice:

pi@raspberrypi:~ $ tvservice --device 2 -s
state 0x6 [DVI CUSTOM RGB full unknown AR], 1440x900 @ 60.00Hz, progressive
pi@raspberrypi:~ $ tvservice --device 2 -m DMT
Group DMT has 16 modes:
           mode 4: 640x480 @ 60Hz 4:3, clock:25MHz progressive
           mode 5: 640x480 @ 72Hz 4:3, clock:31MHz progressive
           mode 6: 640x480 @ 75Hz 4:3, clock:31MHz progressive
           mode 8: 800x600 @ 56Hz 4:3, clock:36MHz progressive
           mode 9: 800x600 @ 60Hz 4:3, clock:40MHz progressive
           mode 10: 800x600 @ 72Hz 4:3, clock:50MHz progressive
           mode 11: 800x600 @ 75Hz 4:3, clock:49MHz progressive
           mode 16: 1024x768 @ 60Hz 4:3, clock:65MHz progressive
           mode 17: 1024x768 @ 70Hz 4:3, clock:75MHz progressive
           mode 18: 1024x768 @ 75Hz 4:3, clock:78MHz progressive
           mode 21: 1152x864 @ 75Hz 4:3, clock:108MHz progressive
           mode 32: 1280x960 @ 60Hz 4:3, clock:108MHz progressive
           mode 35: 1280x1024 @ 60Hz 5:4, clock:108MHz progressive
           mode 36: 1280x1024 @ 75Hz 5:4, clock:135MHz progressive
  (prefer) mode 47: 1440x900 @ 60Hz 16:10, clock:106MHz progressive
           mode 48: 1440x900 @ 75Hz 16:10, clock:136MHz progressive