### PR TITLE
mouse scroll is now enter: multiple scroll will keep moving windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,8 @@ letter 'q'          Quit camplayer.
 ```
 ## Mouse gestures
 Please note there is no absolute positioning, nor any visible mouse. So you cannot jump directly to
-the single view for a specific camera. you need to scroll to camera 1, and then gesture left/right a 
-few times
+the single view for a specific camera. you need to scroll down to camera 1, and then
+either gesture left/right a few times, or scroll down further
 ```
 while holding left button down
 - move left/right   Switch to previous/next screen (or window in single view mode).
@@ -311,7 +311,6 @@ normal actions
 - click right       Pause/unpause automatic screen rotation.
 - scroll up/down    Switch between grid to single view mode.
 ```
--
 ## Roadmap
 ### Camplayer 2
 * Improve VLC and drop OMXplayer support, drop code hacks introduced to support them both.

--- a/camplayer/screenmanager.py
+++ b/camplayer/screenmanager.py
@@ -775,7 +775,7 @@ class ScreenManager(object):
 
         # Switch to single view
         elif action == Action.SWITCH_SINGLE:
-            self._action_switch_single(window_idx=param)
+            self._action_switch_single(window_idx=param, next_window=self._single_window_mode[self._selected_display])
 
         # Switch to previous/next window/screen
         elif action == Action.SWITCH_NEXT or action == Action.SWITCH_PREV:

--- a/camplayer/utils/inputhandler.py
+++ b/camplayer/utils/inputhandler.py
@@ -117,9 +117,9 @@ class InputMonitor(object):
                                     if   (      event.code == evdev.ecodes.REL_WHEEL
                                             and abs(event.value) > 0 ):
                                         if event.value > 0: 
-                                            event.code = evdev.ecodes.KEY_0
+                                            event.code = evdev.ecodes.KEY_ESC
                                         else:
-                                            event.code = evdev.ecodes.KEY_1
+                                            event.code = evdev.ecodes.KEY_ENTER
                                         self._mouse_inhibit = time.monotonic()
                                         self._event_queue.put_nowait(event)
                                     # move left/right while button down is prev/next screen


### PR DESCRIPTION
Just like multiple Enter: first goes to camera 1 single view, then cam 2 view, etc
Scroll up (or Esc) to go back to grid view.