### PR TITLE
Prodding framebuffer to trigger redisplay

### DIFF
--- a/camplayer/camplayer.py
+++ b/camplayer/camplayer.py
@@ -305,6 +305,17 @@ def main():
     utils.kill_service('vlc', force=True)
     utils.kill_service('pipng', force=True)
 
+    # Prodding Framebuffer to get it to display properly again
+    # neither of these commands change the framebuffer, which is better then the
+    # solution I seen where they do the same by setting 32-bit color depth.
+    # Both commands are needed, as each by itself only works once.
+    LOG.DEBUG(_LOG_NAME, "Prodding framebuffer to trigger redisplay.")
+    try:
+        os.system("fbset -move up -step 0")
+        os.system("fbset -a -move up -step 0")
+    except:
+        LOG.DEBUG(_LOG_NAME, "Prodding framebuffer failed.")
+
     LOG.INFO(_LOG_NAME, "Exiting raspberry pi camplayer, have a nice day!")
     sys.exit(0)
 


### PR DESCRIPTION
Often after exiting the screen is black or stuck.
In reality (unless when the GPU is really stuck, which also happens) it still responds to blindly typed commands. And swapping tty with Ctrl-Alt-F1~F7 and back will reset it.

Doing a simple pair of `fbset [-a] -move up -step 0` achieves the same, I think the swapping between with [-a] and without [-a] also triggers a tty swap internally.

In any case, I tried many times, seems to work, in both X and tty